### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Project Issue Tracker
 3) You will add any security features to `server.js`
 4) You will create all of the functional tests in `tests/2_functional-tests.js`
 
+[![Run on Repl.it](https://repl.it/badge/github/jasmeetsohal/fcc-issue-tracker)](https://repl.it/github/jasmeetsohal/fcc-issue-tracker)
+
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jasmeetsohal/fcc-issue-tracker).